### PR TITLE
Update README.md with a note about event bug in tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ API-compatible [yjs](https://github.com/yjs/yjs) CRDT, but faster for game engin
 - Only SFU supported
 - Can only push one element at a time
 - Cannot move elements
+- Pushing a new element and then adding children in the same transaction can have unintended side effects*
+
+* Maybe sure you've fully constructed your object in your transaction before binding it to Z state. If you're getting a message to create an object twice and you shouldn't be, it's possible that this is the issue. Attaching your new state to the old state after you've added any new objects (apps, arrays, etc) in your transaction should prevent this.


### PR DESCRIPTION
We noticed that under certain conditions Z can send an event twice. This doesn't seem to be a problem anywhere in Webaverse except where we were having the avatar trigger twice, and rearranging the code fixed that. Adding a note in case someone else comes across this issue in the future. I don't think that we necessarily should change ZJS by adding a check unless it becomes a problem since it works as expected in the app if you follow the convention. I wouldn't even necessarily describe it as a bug.